### PR TITLE
Updated the libmp4 portfile

### DIFF
--- a/ports/libmp4/portfile.cmake
+++ b/ports/libmp4/portfile.cmake
@@ -3,7 +3,7 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Apra-Labs/libmp4
-    REF b09f055ccd129675c204586eb7691be40e83e246
+    REF a629faa6c4b6cbbdf4f5afa7cd82d85f712c6cb9
     SHA512 233e4f8b65366edf3abdde9141bcee265804b8dda85acaad31ec9ccf97e8e62c84970ee59f56f4472e4f3fb2bf5de2872703afcc6da412f06576f192b8f3c55e
     HEAD_REF forApraPipes
 )

--- a/ports/libmp4/portfile.cmake
+++ b/ports/libmp4/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO Apra-Labs/libmp4
     REF a629faa6c4b6cbbdf4f5afa7cd82d85f712c6cb9
-    SHA512 233e4f8b65366edf3abdde9141bcee265804b8dda85acaad31ec9ccf97e8e62c84970ee59f56f4472e4f3fb2bf5de2872703afcc6da412f06576f192b8f3c55e
+    SHA512 f82c65a7e16764815cd1de8b3b3c81dbc2f612aa7c91f5db165d0b22ca54931329ee3a1e39b1ac6c47b1348734881ad6617fcf743117605e0e86183b99081250
     HEAD_REF forApraPipes
 )
 vcpkg_configure_cmake(

--- a/versions/l-/libmp4.json
+++ b/versions/l-/libmp4.json
@@ -1,7 +1,7 @@
 {
     "versions": [
       {
-        "git-tree": "c11c1dc63ed36f93e539b4af6f99e763d4b6855a",
+        "git-tree": "970a1e7beae46ef04d6585de8d79af72a66ca2cf",
         "version": "1.0"
       }
     ]

--- a/versions/l-/libmp4.json
+++ b/versions/l-/libmp4.json
@@ -1,7 +1,7 @@
 {
     "versions": [
       {
-        "git-tree": "970a1e7beae46ef04d6585de8d79af72a66ca2cf",
+        "git-tree": "d9898c1a8b5c2fbef23242d5f9e1e9571d384aee",
         "version": "1.0"
       }
     ]


### PR DESCRIPTION
<!-- If your PR fixes issues, please note that here by adding "Fixes #NNNNNN." for each fixed issue on separate lines. -->

<!-- If you are still working on the PR, open it as a Draft: https://github.blog/2019-02-14-introducing-draft-pull-requests/ -->

<!-- If this PR updates an existing port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] SHA512s are updated for each updated download
- [ ] The "supports" clause reflects platforms that may be fixed by this new version
- [ ] Any fixed [CI baseline](https://github.com/microsoft/vcpkg/blob/master/scripts/ci.baseline.txt) entries are removed from that file.
- [ ] Any patches that are no longer applied are deleted from the port's directory.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is added to each modified port's versions file.

END OF PORT UPDATE CHECKLIST (delete this line) -->

<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html)
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See docs/examples/adding-an-explicit-usage.md for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
